### PR TITLE
Fix pitrery.spec according to rpmlint

### DIFF
--- a/rpm/pitrery.spec
+++ b/rpm/pitrery.spec
@@ -10,7 +10,7 @@ Summary:        Point-In-Time Recovery tools for PostgreSQL
 License:        BSD
 Group:          Applications/Databases
 URL:            https://github.com/dalibo/pitrery
-Source0:        %{pkgname}-%{version}.tar.gz
+Source0:        https://dl.dalibo.com/public/pitrery/%{pkgname}-%{version}.tar.gz
 Patch1:         pitrery.config.patch
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
@@ -61,7 +61,7 @@ make install DESTDIR=%{buildroot}
 * Tue May 23 2017 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.13-1
 - Update to 1.13
 
-* Wed Nov 18 2016 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.12-1
+* Fri Nov 18 2016 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.12-1
 - Update to 1.12
 
 * Mon Jun 20 2016 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.11-1


### PR DESCRIPTION
rpmlint reported 1 error :
pitrery.spec: E: specfile-error warning: bogus date in %changelog: Wed Nov 18 2016 Nicolas Thauvin <nicolas.thauvin@dalibo.com> - 1.12-1
because November 18 was a friday, not a wednesday :/

and 1 warning :
pitrery.spec: W: invalid-url Source0: pitrery-1.13.tar.gz