### PR TITLE
Fix parse_target_uri to resolve absolute paths even in remote mode.

### DIFF
--- a/pitrery
+++ b/pitrery
@@ -315,7 +315,7 @@ parse_target_uri() {
     [ -n "$backup_dir" ] || error "missing backup directory"
 
     # Ensure the backup directory is an absolute path
-    backup_dir="$(readlink -f -- "$backup_dir")"
+    backup_dir="$(readlink -m -- "$backup_dir")"
     
     # Deduce if backup is local
     if [ -z "$backup_host" ]; then
@@ -365,7 +365,7 @@ parse_target_uri() {
     [ -n "$archive_dir" ] || error "missing archive directory"
 
     # Ensure the achives directory is an absolute path
-    archive_dir="$(readlink -f -- "$archive_dir")"
+    archive_dir="$(readlink -m -- "$archive_dir")"
 
     return $out_rc
 }


### PR DESCRIPTION
Use readlink -m when parsing paths. This ensures that the paths are correctly canonicalized, even they don't exist on the current server - which is the case if the backup is stored on a remote server.
