### PR TITLE
Add Arch Linux packaging directory

### DIFF
--- a/archlinux/.SRCINFO
+++ b/archlinux/.SRCINFO
@@ -11,6 +11,7 @@ pkgbase = pitrery
 	backup = etc/pitrery/pitrery.conf
 	source = https://dl.dalibo.com/public/pitrery/pitrery-2.1.tar.gz
 	source = https://dl.dalibo.com/public/pitrery/pitrery-2.1.tar.gz.asc
+	validpgpkeys = A9C12688B6D6A1A66A9FE2BC36B6559CD664AA4D
 	sha256sums = 465b8aa803df053d7d8f462625b235b67b537f9cd982059af768e999046d2d73
 	sha256sums = 1d89a75a79fd7b0df933312913bf256a11ac7f6d524eade1ad8ae7609343d36d
 

--- a/archlinux/.SRCINFO
+++ b/archlinux/.SRCINFO
@@ -1,0 +1,18 @@
+pkgbase = pitrery
+	pkgdesc = Point In Time Recovery tools for PostgreSQL
+	pkgver = 2.1
+	pkgrel = 1
+	url = https://dalibo.github.io/pitrery/
+	arch = any
+	license = BSD
+	depends = bash
+	optdepends = openssh: used for remote backups
+	optdepends = rsync: used for network WAL archiving
+	backup = etc/pitrery/pitrery.conf
+	source = https://dl.dalibo.com/public/pitrery/pitrery-2.1.tar.gz
+	source = https://dl.dalibo.com/public/pitrery/pitrery-2.1.tar.gz.asc
+	sha256sums = 465b8aa803df053d7d8f462625b235b67b537f9cd982059af768e999046d2d73
+	sha256sums = 1d89a75a79fd7b0df933312913bf256a11ac7f6d524eade1ad8ae7609343d36d
+
+pkgname = pitrery
+

--- a/archlinux/.SRCINFO
+++ b/archlinux/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = pitrery
 	pkgdesc = Point In Time Recovery tools for PostgreSQL
-	pkgver = 2.1
+	pkgver = 2.2
 	pkgrel = 1
 	url = https://dalibo.github.io/pitrery/
 	arch = any
@@ -9,11 +9,10 @@ pkgbase = pitrery
 	optdepends = openssh: used for remote backups
 	optdepends = rsync: used for network WAL archiving
 	backup = etc/pitrery/pitrery.conf
-	source = https://dl.dalibo.com/public/pitrery/pitrery-2.1.tar.gz
-	source = https://dl.dalibo.com/public/pitrery/pitrery-2.1.tar.gz.asc
+	source = https://dl.dalibo.com/public/pitrery/pitrery-2.2.tar.gz
+	source = https://dl.dalibo.com/public/pitrery/pitrery-2.2.tar.gz.asc
 	validpgpkeys = A9C12688B6D6A1A66A9FE2BC36B6559CD664AA4D
-	sha256sums = 465b8aa803df053d7d8f462625b235b67b537f9cd982059af768e999046d2d73
-	sha256sums = 1d89a75a79fd7b0df933312913bf256a11ac7f6d524eade1ad8ae7609343d36d
+	sha256sums = eb54a2a9e5168067f2e87525ce86ae98b836a9fe7491f15a2bb37964bd2b3470
+	sha256sums = 3143a1535d03267ba8ecc37b72b58683777c185a5bbd58fa3e3cdc4399e68ab8
 
 pkgname = pitrery
-

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Pierre-Alain TORET <pierre-alain.toret@protonmail.com>
 pkgname=pitrery
-pkgver=2.1
+pkgver=2.2
 pkgrel=1
 pkgdesc="Point In Time Recovery tools for PostgreSQL"
 arch=("any")
@@ -9,8 +9,10 @@ optdepends=("openssh: used for remote backups" "rsync: used for network WAL arch
 url="https://dalibo.github.io/pitrery/"
 license=("BSD")
 backup=('etc/pitrery/pitrery.conf')
-source=("https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz" "https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz.asc")
-sha256sums=("465b8aa803df053d7d8f462625b235b67b537f9cd982059af768e999046d2d73" "1d89a75a79fd7b0df933312913bf256a11ac7f6d524eade1ad8ae7609343d36d")
+source=("https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz" 
+        "https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz.asc")
+sha256sums=("eb54a2a9e5168067f2e87525ce86ae98b836a9fe7491f15a2bb37964bd2b3470"
+            "3143a1535d03267ba8ecc37b72b58683777c185a5bbd58fa3e3cdc4399e68ab8")
 validpgpkeys=("A9C12688B6D6A1A66A9FE2BC36B6559CD664AA4D")
 
 build() {

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -11,6 +11,7 @@ license=("BSD")
 backup=('etc/pitrery/pitrery.conf')
 source=("https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz" "https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz.asc")
 sha256sums=("465b8aa803df053d7d8f462625b235b67b537f9cd982059af768e999046d2d73" "1d89a75a79fd7b0df933312913bf256a11ac7f6d524eade1ad8ae7609343d36d")
+validpgpkeys=("A9C12688B6D6A1A66A9FE2BC36B6559CD664AA4D")
 
 build() {
 	cd "$pkgname-$pkgver"

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Pierre-Alain TORET <pierre-alain.toret@protonmail.com>
+pkgname=pitrery
+pkgver=2.1
+pkgrel=1
+pkgdesc="Point In Time Recovery tools for PostgreSQL"
+arch=("any")
+depends=("bash")
+optdepends=("openssh: used for remote backups" "rsync: used for network WAL archiving")
+url="https://dalibo.github.io/pitrery/"
+license=("BSD")
+backup=('etc/pitrery/pitrery.conf')
+source=("https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz" "https://dl.dalibo.com/public/pitrery/pitrery-$pkgver.tar.gz.asc")
+sha256sums=("465b8aa803df053d7d8f462625b235b67b537f9cd982059af768e999046d2d73" "1d89a75a79fd7b0df933312913bf256a11ac7f6d524eade1ad8ae7609343d36d")
+
+build() {
+	cd "$pkgname-$pkgver"
+	sed -i  's@PREFIX = /usr/local@PREFIX = /usr@;s@SYSCONFDIR = ${PREFIX}/etc/${NAME}@SYSCONFDIR = /etc/${NAME}@' config.mk
+	make
+}
+
+package() {
+	cd "$pkgname-$pkgver"
+	make DESTDIR="$pkgdir" install
+	install -Dm644 COPYRIGHT "$pkgdir/usr/share/licenses/$pkgname/COPYRIGHT"
+}

--- a/archlinux/docker-compose.yml
+++ b/archlinux/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+services:
+  makepkg:
+    image: archlinux/base
+    volumes:
+    - .:/srv
+    entrypoint: /srv/run

--- a/archlinux/run
+++ b/archlinux/run
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+cd $(readlink -m $0/..)
+
+rm -f /var/lib/pacman/db.lck
+
+pacman -Syy
+pacman -S --noconfirm sudo base-devel gnupg
+
+useradd -m makepkg
+
+cp -a /srv/PKGBUILD  /home/makepkg
+
+su - makepkg -c "gpg --receive-keys A9C12688B6D6A1A66A9FE2BC36B6559CD664AA4D && makepkg -f -c -s"
+
+cp -a /home/makepkg/pitrery-*.tar.xz /srv/


### PR DESCRIPTION
Hello,

I did add pitrery as a package in the [AUR](https://aur.archlinux.org/packages/pitrery/) (Arch Linux user repository) : 
I don't know if it makes much sense to have the package definition in the github repo of pitrery but as there are the deb and rpm files, I thought why not.
Anyway, tell me what do you think of it.

Regards,