### PR TITLE
Warn about untested Postgres version

### DIFF
--- a/pitrery
+++ b/pitrery
@@ -25,6 +25,7 @@
 #
 
 version="2.3"
+latest_supported_pg_version=1100
 
 # Hardcoded configuration
 PGXLOG=
@@ -2939,6 +2940,11 @@ case $action in
         info "and do not forget to update the configuration of pitrery if needed:"
         info "  $PGDATA/recovery.conf"
         info
+
+        if (( $pgvers > $latest_supported_pg_version )) ; then
+            warn "This version of PostgreSQL is not tested with Pitrery $version!"
+            warn "It is likely that the cluster needs manual tweaks before starting."
+        fi
 
         if [ -f "$replslots_sql" ]; then
             if [[ $(cat "$replslots_sql" | wc -l) > 0 ]]; then


### PR DESCRIPTION
cc @madtibo @tilkow @DeepDiver13 @Krysztophe 

```
root@pitrery:~# sudo -iu postgres pitrery restore -D /var/lib/postgresql/11/rest/ -R
...
2019-08-28 15:10:14 UTC INFO:
2019-08-28 15:10:14 UTC INFO: saved configuration files have been restored to:                                                          
2019-08-28 15:10:14 UTC INFO:   /var/lib/postgresql/11/rest//restored_config_files                                                      
2019-08-28 15:10:14 UTC INFO:
2019-08-28 15:10:14 UTC INFO: please check directories and recovery.conf before starting the cluster                                    
2019-08-28 15:10:14 UTC INFO: and do not forget to update the configuration of pitrery if needed:                                       
2019-08-28 15:10:14 UTC INFO:   /var/lib/postgresql/11/rest//recovery.conf                                                              
2019-08-28 15:10:14 UTC INFO:
2019-08-28 15:10:14 UTC WARNING: This version of Postgres is not tested with Pitrery, you may likely require                            
2019-08-28 15:10:14 UTC WARNING: manual tweaks before starting the cluster.   
root@pitrery:~#
```