### PR TITLE
purge was not working for bash before 4.2

### DIFF
--- a/pitrery
+++ b/pitrery
@@ -24,7 +24,7 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-version="2.4"
+version="2.5"
 latest_supported_pg_version=1100
 
 # Hardcoded configuration
@@ -248,7 +248,7 @@ usage() {
 # which should not be interpreted or cause word-splitting on the remote side.
 qw() {
     printf -v out "%q " "$@"
-    echo "${out::-1}"  # Skip the final space.
+    echo ${out%?} # Skip the final space
 }
 
 can_cleanup="no"
@@ -3252,11 +3252,11 @@ case $action in
 	            # command with too many arguments.
 	            if [ "$archive_local" = "yes" ]; then
 	                for wal in "${wal_purge_list[@]}"; do
-		            echo "rm -- $(qw "$wal")"
+	                	echo "rm -- \"${wal}\""
 	                done | bash || die "unable to remove wal files"
 	            else
 	                for wal in "${wal_purge_list[@]}"; do
-		            echo "rm -- $(qw "$wal")"
+	                	echo "rm -- \"${wal}\""
 	                done | ssh -- "$archive_ssh_target" "cat | sh" || die "unable to remove wal files on $archive_host"
 	            fi
                 fi


### PR DESCRIPTION
Negative length specifications in the ${var:offset:length} expansion, appeared in bash 4.2.
We must be try to be the most compatible as possible so change to be compatible with at least bash 2.0 and greater.