### PR TITLE
purge was not working for bash before 4.2

### DIFF
--- a/pitrery
+++ b/pitrery
@@ -3345,7 +3345,7 @@ case $action in
 					# command with too many arguments.
 					if [ "$archive_local" = "yes" ]; then
 						for wal in "${wal_purge_list[@]}"; do
-              echo "rm -- \"${wal}\""
+							echo "rm -- \"${wal}\""
 						done | bash || die "unable to remove wal files"
 					else
 						for wal in "${wal_purge_list[@]}"; do

--- a/pitrery
+++ b/pitrery
@@ -251,7 +251,7 @@ usage() {
 # which should not be interpreted or cause word-splitting on the remote side.
 qw() {
 	printf -v out "%q " "$@"
-	echo "${out::-1}"  # Skip the final space.
+	echo ${out%?}  # Skip the final space.
 }
 
 can_cleanup="no"
@@ -3345,11 +3345,11 @@ case $action in
 					# command with too many arguments.
 					if [ "$archive_local" = "yes" ]; then
 						for wal in "${wal_purge_list[@]}"; do
-							echo "rm -- $(qw "$wal")"
+              echo "rm -- \"${wal}\""
 						done | bash || die "unable to remove wal files"
 					else
 						for wal in "${wal_purge_list[@]}"; do
-							echo "rm -- $(qw "$wal")"
+							echo "rm -- \"${wal}\""
 						done | ssh -- "$archive_ssh_target" "cat | sh" || die "unable to remove wal files on $archive_host"
 					fi
 				fi


### PR DESCRIPTION
#79 

Since eeba3e307, the purge script was broken for bash lesser than 4.2.

The function qw was using the bashism: `echo "${out::-1}"`
bash 4.2 CHANGES gave this possible grammar:
"_Negative length specifications in the ${var:offset:length} expansion, previously errors, are now treated as offsets from the end of the variable._"

This update give compatibility to at least bash 2.0+.