### PR TITLE
Pitrery 3 deb

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ pitrery (3.0-1) buster; urgency=medium
   * Compatible with PostgreSQL 12
   * Rename 'xlog' to 'wal' in scripts and parameters
 
- -- Thibaut MADELAINE <thibaut.madelaine@dalibo.com> Fri, 27 Dec 2019 11:32:00 +000
+ -- Thibaut MADELAINE <thibaut.madelaine@dalibo.com>  Mon, 30 Dec 2019 16:44:00 +0200
 
 pitrery (2.4-1) buster; urgency=medium
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -3,14 +3,14 @@
 set -e
 
 case "$1" in
-	upgrade)
-		if [ -e /usr/bin/archive_xlog_to_wal ] ; then
-			rm -f /usr/bin/archive_xlog_to_wal
-			ln -s /usr/bin/archive_wal /usr/bin/archive_xlog
-		fi
-		if [ -e /usr/bin/restore_xlog_to_wal ] ; then
-			rm -f /usr/bin/restore_xlog_to_wal
-			ln -s /usr/bin/restore_wal /usr/bin/restore_xlog
-		fi
-	;;
+  configure)
+    if [ -e /usr/bin/archive_xlog_to_wal ] ; then
+      rm -f /usr/bin/archive_xlog_to_wal
+      ln -s /usr/bin/archive_wal /usr/bin/archive_xlog
+    fi
+    if [ -e /usr/bin/restore_xlog_to_wal ] ; then
+      rm -f /usr/bin/restore_xlog_to_wal
+      ln -s /usr/bin/restore_wal /usr/bin/restore_xlog
+    fi
+  ;;
 esac

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+set -e
+
+case "$1" in
+  upgrade)
+    if [ -e /usr/bin/archive_xlog ] && [ ! -h /usr/bin/archive_xlog ] ; then
+      touch /usr/bin/archive_xlog_to_wal
+    fi
+    if [ -e /usr/bin/restore_xlog ] && [ ! -h /usr/bin/restore_xlog ] ; then
+      touch /usr/bin/restore_xlog_to_wal
+    fi
+  ;;
+esac

--- a/debian/prerm
+++ b/debian/prerm
@@ -3,12 +3,12 @@
 set -e
 
 case "$1" in
-	upgrade)
-		if [ -e /usr/bin/archive_xlog ] && [ ! -h /usr/bin/archive_xlog ] ; then
-			touch /usr/bin/archive_xlog_to_wal
-		fi
-		if [ -e /usr/bin/restore_xlog ] && [ ! -h /usr/bin/restore_xlog ] ; then
-			touch /usr/bin/restore_xlog_to_wal
-		fi
-	;;
+    remove)
+        if [ -h /usr/bin/archive_xlog ] ; then
+            rm -f /usr/bin/archive_xlog
+        fi
+        if [ -h /usr/bin/restore_xlog ] ; then
+           rm -f /usr/bin/restore_xlog
+        fi
+    ;;
 esac


### PR DESCRIPTION
Create a symbolic link from /usr/bin/(archive|restore)_xlog to  /usr/bin/(archive|restore)_wal on debian package upgrade.