### PR TITLE
Add CentOS tests (#102)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,5 @@ workflows:
   func:
     jobs:
       - centos7:
-          pg_version: '9.6'
-      - centos7:
           pg_version: '10'
-      - centos7:
-          pg_version: '11'
       - centos7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ version: 2.1
       command:  |
         echo "archive_mode = on" >> /tmp/pgsql/postgresql.auto.conf
         echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.auto.conf
-        echo "archive_command = '/usr/local/bin/archive_wal -a '/tmp/backup/archived_wal' %p'" >>/tmp/pgsql/postgresql.auto.conf
+        echo "archive_command = '/usr/local/bin/archive_wal -a /tmp/backup/archived_wal %p'" >>/tmp/pgsql/postgresql.auto.conf
   - run:
       name: start postgresql
       command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,10 @@ version: 2.1
       name: Install pitrery
       command: make install
   - run:
-      name: name install bats
+      name: name install bats and shellcheck
       command: yum -y install bats shellcheck
   - run:
-      name: Execute tests
+      name: Change ownership
       command: chown -R postgres:postgres ./tests/
   - run:
       name: Execute tests func

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,40 @@
 version: 2.1
+.tests-centos-job: &tests-centos-job
+  docker: [{image: "dalibo/temboard-agent-sdk:centos7" }]
+  working_directory: /tmp/project/ # tmp bats scripts will be used by postgres user
+  parameters:
+    pg_version:
+      type: string
+      default: '12'
+  steps:
+  - run:
+      name: initdb and start postgresql
+      command: sudo -su postgres /usr/pgsql-<< parameters.pg_version >>/bin/initdb -D /tmp/pgsql
+  - run:
+      name: Set wal_level to replica
+      command:  |
+        echo "archive_mode = on" >> /tmp/pgsql/postgresql.conf
+        echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.conf
+        echo "archive_command = '/usr/local/bin/archive_wal -C /tmp/project/tests/pitrery.conf %p'" >>/tmp/pgsql/postgresql.conf
+  - run:
+      name: start postgresql
+      command: |
+        cd /tmp
+        sudo -su postgres /usr/pgsql-<< parameters.pg_version >>/bin/pg_ctl start -w -D /tmp/pgsql -l /tmp/logfile
+  - checkout
+  - run:
+      name: Install pitrery
+      command: make install
+  - run:
+      name: name install bats
+      command: yum -y install bats shellcheck
+  - run:
+      name: Execute tests
+      command: chown -R postgres:postgres ./tests/
+  - run:
+      name: Execute tests func
+      command: sudo -su postgres bats -t tests/func.bats
+
 jobs:
   shellcheck:
     docker: [{image: "koalaman/shellcheck-alpine:stable"}]
@@ -8,8 +44,21 @@ jobs:
     - run:
         name: Shellcheck code analysis
         command: shellcheck -f gcc pitrery archive_wal restore_wal
+  centos7:
+    <<: *tests-centos-job
+
+
 workflows:
   version: 2
   shellcheck:
     jobs:
       - shellcheck
+  func:
+    jobs:
+      - centos7:
+          pg_version: '9.6'
+      - centos7:
+          pg_version: '10'
+      - centos7:
+          pg_version: '11'
+      - centos7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ version: 2.1
       command:  |
         echo "archive_mode = on" >> /tmp/pgsql/postgresql.auto.conf
         echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.auto.conf
-        echo "archive_command = '/usr/local/bin/archive_wal -C /tmp/project/tests/pitrery.conf %p'" >>/tmp/pgsql/postgresql.auto.conf
+        echo "archive_command = '/usr/local/bin/archive_wal -a '/tmp/backup/archived_wal' %p'" >>/tmp/pgsql/postgresql.auto.conf
   - run:
       name: start postgresql
       command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ version: 2.1
   - run:
       name: Set wal_level to replica
       command:  |
-        echo "archive_mode = on" >> /tmp/pgsql/postgresql.conf
-        echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.conf
-        echo "archive_command = '/usr/local/bin/archive_wal -C /tmp/project/tests/pitrery.conf %p'" >>/tmp/pgsql/postgresql.conf
+        echo "archive_mode = on" >> /tmp/pgsql/postgresql.auto.conf
+        echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.auto.conf
+        echo "archive_command = '/usr/local/bin/archive_wal -C /tmp/project/tests/pitrery.conf %p'" >>/tmp/pgsql/postgresql.auto.conf
   - run:
       name: start postgresql
       command: |

--- a/pitrery
+++ b/pitrery
@@ -1532,7 +1532,8 @@ case $action in
 				fi
 			}
 
-			# Check if the connection works by getting the pid of the backend
+			# Check if t
+			he connection works by getting the pid of the backend
 			echo 'select pg_backend_pid();' >&${COPROC[1]} # 2>/dev/null
 			if [ $? != 0 ]; then
 				check_psql_stderr || cat $psql_stderr

--- a/pitrery
+++ b/pitrery
@@ -4107,7 +4107,7 @@ case $action in
 		# target directory for backups must be provided
 		if [ -z "${@:$OPTIND:1}" ]; then
 			error "missing target backup directory"
-			usage "configure"
+			usage "configure" 1
 		fi
 
 		# Only tar and rsync are allowed as storage method
@@ -4125,7 +4125,7 @@ case $action in
 			die "list of recipients for GPG encryption missing"
 		fi
 
-		parse_target_uri "${@:$OPTIND:1}" "$archive_path" || usage "configure"
+		parse_target_uri "${@:$OPTIND:1}" "$archive_path" || usage "configure" 1
 
 		# the configuration for archive_wal must be an absolute path or
 		# relative to PGDATA. Just convert it to a absolute path if needed,

--- a/tests/func.bats
+++ b/tests/func.bats
@@ -55,5 +55,5 @@ setup()
   output=(${output})
   unset IFS
   [ "${#output[@]}" -eq 2 ]
-  [[ "$output[1]" == "$PITRERY_BACKUP_DIR"* ]]
+  [[ "${output[1]}" == "$PITRERY_BACKUP_DIR"* ]]
 }

--- a/tests/func.bats
+++ b/tests/func.bats
@@ -12,7 +12,7 @@ setup()
 
 @test "First dummy check - trying to run help action" {
     run pitrery help
-	[ "${lines[0]}" == 'pitrery 3.0 - PostgreSQL Point In Time Recovery made easy' ]
+	[ "${lines[0]}" == 'pitrery 3.1 - PostgreSQL Point In Time Recovery made easy' ]
     echo "output = ${output}"
 }
 

--- a/tests/func.bats
+++ b/tests/func.bats
@@ -33,6 +33,11 @@ setup()
   [ "$status" -eq 0 ]
 }
 
+@test "Testing list action with local config and no backups" {
+  run pitrery -f $PITRERY_LOCAL_CONF list
+  [ "$status" -eq 1 ]
+}
+
 @test "Testing backup action with local config" {
   run pitrery -f $PITRERY_LOCAL_CONF backup
   [ "$status" -eq 0 ]
@@ -40,9 +45,15 @@ setup()
   [[ "$output" == *"INFO: preparing directories"* ]]
   [[ "$output" == *"INFO: backing up PGDATA"* ]]
   [[ "$output" == *"INFO: done"* ]]
+  # TODO get backup path name to verify next list test
 }
 
 @test "Testing list action with local config" {
   run pitrery -f $PITRERY_LOCAL_CONF list
+  [ "$status" -eq 0 ]
+  IFS=$'\n'
+  output=(${output})
+  unset IFS
   [ "${#output[@]}" -eq 2 ]
+  [[ "$output[1]" == "$PITRERY_BACKUP_DIR"* ]]
 }

--- a/tests/func.bats
+++ b/tests/func.bats
@@ -20,24 +20,29 @@ setup()
 }
 
 @test "Testing configure action without parameter" {
-  run pitrery configure -f -o $PITRERY_LOCAL_CONF $PITRERY_BACKUP_DIR
-  [ "$status" -eq 0 ]
+  run pitrery configure
+  [ "$status" -eq 1 ]
 }
 
 @test "Testing backup action without config" {
   run pitrery backup
+  [ "$status" -eq 1 ]
+}
+@test "Testing configure action with local parameters" {
+  run pitrery configure -f -o $PITRERY_LOCAL_CONF $PITRERY_BACKUP_DIR
   [ "$status" -eq 0 ]
 }
 
-@test "Testing backup action with custom config" {
-  run pitrery -f ./tests/pitrery.conf backup
+@test "Testing backup action with local config" {
+  run pitrery -f $PITRERY_LOCAL_CONF backup
+  [ "$status" -eq 0 ]
   echo "output = ${output}"
   [[ "$output" == *"INFO: preparing directories"* ]]
   [[ "$output" == *"INFO: backing up PGDATA"* ]]
   [[ "$output" == *"INFO: done"* ]]
 }
 
-@test "Testing list action with custom config" {
-  run pitrery -f ./tests/pitrery.conf list
+@test "Testing list action with local config" {
+  run pitrery -f $PITRERY_LOCAL_CONF list
   [ "${#output[@]}" -eq 2 ]
 }

--- a/tests/func.bats
+++ b/tests/func.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+setup()
+{
+	export PATH=/usr/local/bin/:$PATH
+
+}
+
+#teardown()
+#{
+#	# teardown function
+#}
+
+@test "First dummy check - trying to run help action" {
+    run pitrery help
+	[ "${lines[0]}" == 'pitrery 3.0 - PostgreSQL Point In Time Recovery made easy' ]
+    echo "output = ${output}"
+}
+
+@test "Testing configure action without parameter" {
+  run pitrery configure
+  [ "$status" -eq 1 ]
+}
+
+@test "Testing backup action without config" {
+  run pitrery backup
+  [ "$status" -eq 1 ]
+}
+
+@test "Testing backup action with custom config" {
+  run pitrery -f ./tests/pitrery.conf backup
+  echo "output = ${output}"
+  [[ "$output" == *"INFO: preparing directories"* ]]
+  [[ "$output" == *"INFO: backing up PGDATA"* ]]
+  [[ "$output" == *"INFO: done"* ]]
+}
+
+@test "Testing list action with custom config" {
+  run pitrery -f ./tests/pitrery.conf list
+  [ "${#output[@]}" -eq 2 ]
+}

--- a/tests/func.bats
+++ b/tests/func.bats
@@ -2,7 +2,10 @@
 setup()
 {
 	export PATH=/usr/local/bin/:$PATH
-
+	export PITRERY_BACKUP_DIR=/tmp/backup
+	export PITRERY_LOCAL_CONF=/tmp/pitrery_local.conf
+	export PITRERY_REMOTE_CONF=/tmp/pitrery_remote.conf
+	mkdir -p $PITRERY_BACKUP_DIR
 }
 
 #teardown()
@@ -17,13 +20,13 @@ setup()
 }
 
 @test "Testing configure action without parameter" {
-  run pitrery configure
-  [ "$status" -eq 1 ]
+  run pitrery configure -f -o $PITRERY_LOCAL_CONF $PITRERY_BACKUP_DIR
+  [ "$status" -eq 0 ]
 }
 
 @test "Testing backup action without config" {
   run pitrery backup
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
 }
 
 @test "Testing backup action with custom config" {

--- a/tests/pitrery.conf
+++ b/tests/pitrery.conf
@@ -1,0 +1,5 @@
+PGDATA="/tmp/pgsql"
+BACKUP_DIR="/tmp/backup"
+PURGE_KEEP_COUNT="2"
+STORAGE="tar"
+ARCHIVE_DIR="/tmp/backup/archived_wal"

--- a/tests/pitrery.conf
+++ b/tests/pitrery.conf
@@ -1,5 +1,0 @@
-PGDATA="/tmp/pgsql"
-BACKUP_DIR="/tmp/backup"
-PURGE_KEEP_COUNT="2"
-STORAGE="tar"
-ARCHIVE_DIR="/tmp/backup/archived_wal"


### PR DESCRIPTION
* [tests] Add conf for CentOS7 - PG9.6, 10, 11 & 12

* Reuse temboard-agent-sdk docker image

Simply re-use the centos temboard-agent-sdk image. So we don't
have to define job just to install postgres through our circleci
config file

* Remove useless job definition

* [Tests] Add first bunch of tests

Currently we only test pitrery by calling the script directly. It could
be nice to split it into small "testable" function

Co-authored-by: l00ptr <julian.vandenbroeck@dalibo.com>