### PR TITLE
WIP [CI] phase 1: add functional tests for several OS and PG versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,40 @@
 version: 2.1
+.tests-centos-job: &tests-centos-job
+  docker: [{image: "dalibo/temboard-agent-sdk:centos7" }]
+  working_directory: /tmp/project/ # tmp bats scripts will be used by postgres user
+  parameters:
+    pg_version:
+      type: string
+      default: '12'
+  steps:
+  - run:
+      name: initdb and start postgresql
+      command: sudo -su postgres /usr/pgsql-<< parameters.pg_version >>/bin/initdb -D /tmp/pgsql
+  - run:
+      name: Set wal_level to replica
+      command:  |
+        echo "archive_mode = on" >> /tmp/pgsql/postgresql.auto.conf
+        echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.auto.conf
+        echo "archive_command = '/usr/local/bin/archive_wal -a /tmp/backup/archived_wal %p'" >>/tmp/pgsql/postgresql.auto.conf
+  - run:
+      name: start postgresql
+      command: |
+        cd /tmp
+        sudo -su postgres /usr/pgsql-<< parameters.pg_version >>/bin/pg_ctl start -w -D /tmp/pgsql -l /tmp/logfile
+  - checkout
+  - run:
+      name: Install pitrery
+      command: make install
+  - run:
+      name: name install bats and shellcheck
+      command: yum -y install bats shellcheck
+  - run:
+      name: Change ownership
+      command: chown -R postgres:postgres ./tests/
+  - run:
+      name: Execute tests func
+      command: sudo -su postgres bats -t tests/func.bats
+
 jobs:
   shellcheck:
     docker: [{image: "koalaman/shellcheck-alpine:stable"}]
@@ -8,8 +44,17 @@ jobs:
     - run:
         name: Shellcheck code analysis
         command: shellcheck -f gcc pitrery archive_wal restore_wal
+  centos7:
+    <<: *tests-centos-job
+
+
 workflows:
   version: 2
   shellcheck:
     jobs:
       - shellcheck
+  func:
+    jobs:
+      - centos7:
+          pg_version: '10'
+      - centos7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,60 +1,142 @@
 version: 2.1
-.tests-centos-job: &tests-centos-job
-  docker: [{image: "dalibo/temboard-agent-sdk:centos7" }]
-  working_directory: /tmp/project/ # tmp bats scripts will be used by postgres user
-  parameters:
-    pg_version:
-      type: string
-      default: '12'
-  steps:
-  - run:
-      name: initdb and start postgresql
-      command: sudo -su postgres /usr/pgsql-<< parameters.pg_version >>/bin/initdb -D /tmp/pgsql
-  - run:
-      name: Set wal_level to replica
-      command:  |
-        echo "archive_mode = on" >> /tmp/pgsql/postgresql.auto.conf
-        echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.auto.conf
-        echo "archive_command = '/usr/local/bin/archive_wal -a /tmp/backup/archived_wal %p'" >>/tmp/pgsql/postgresql.auto.conf
-  - run:
-      name: start postgresql
-      command: |
-        cd /tmp
-        sudo -su postgres /usr/pgsql-<< parameters.pg_version >>/bin/pg_ctl start -w -D /tmp/pgsql -l /tmp/logfile
-  - checkout
-  - run:
-      name: Install pitrery
-      command: make install
-  - run:
-      name: name install bats and shellcheck
-      command: yum -y install bats shellcheck
-  - run:
-      name: Change ownership
-      command: chown -R postgres:postgres ./tests/
-  - run:
-      name: Execute tests func
-      command: sudo -su postgres bats -t tests/func.bats
+
+centos_env: &centos_env
+  environment:
+    PACKAGE_INSTALL: "yum -y "
+    PG_BINDIR: "/usr/pgsql-"
+    PG_VERSION: 12
+  shell: /bin/bash
+  working_directory: /tmp/project/
+
+debian_env: &debian_env
+  environment:
+    PACKAGE_INSTALL: "apt -y "
+    PG_BINDIR: "/usr/lib/postgresql/"
+    PG_VERSION: 12
+  shell: /bin/bash
+  working_directory: /tmp/project/
+
+executors:
+  centos6:
+    docker: [{ image: "dalibo/temboard-agent-sdk:centos6" }]
+    <<: *centos_env
+
+  centos7:
+    docker: [{ image: "dalibo/temboard-agent-sdk:centos7" }]
+    <<: *centos_env
+
+  buster:
+    docker: [{ image: "dalibo/temboard-agent-sdk:buster" }]
+    <<: *debian_env
+
+  stretch:
+    docker: [{ image: "dalibo/temboard-agent-sdk:stretch" }]
+    <<: *debian_env
+
+commands:
+  update-packages:
+    description: update packages
+    steps:
+      - run:
+          command: |
+            ${PACKAGE_INSTALL} update
+
+  shellcheck-job:
+    description: run shellcheck on scripts
+    steps:
+      - run:
+          name: name install shellcheck
+          command: ${PACKAGE_INSTALL} install shellcheck
+      - run:
+          name: Shellcheck code analysis
+          command: shellcheck -f gcc pitrery archive_wal restore_wal
+
+  init-cluster-job:
+    description: initialise PostgreSQL cluster
+    steps:
+      - run:
+          name: initdb and start PostgreSQL
+          command: sudo -su postgres ${PG_BINDIR}${PG_VERSION}/bin/initdb -D /tmp/pgsql
+      - run:
+          name: Setup archiving
+          command:  |
+            echo "archive_mode = on" >> /tmp/pgsql/postgresql.auto.conf
+            echo "wal_level = 'replica'" >> /tmp/pgsql/postgresql.auto.conf
+            echo "archive_command = '/usr/local/bin/archive_wal -a /tmp/backup/archived_wal %p'" >>/tmp/pgsql/postgresql.auto.conf
+      - run:
+          name: start PostgreSQL
+          command: |
+            cd /tmp
+            sudo -su postgres ${PG_BINDIR}${PG_VERSION}/bin/pg_ctl start -w -D /tmp/pgsql -l /tmp/logfile
+
+  tests-func-job:
+    description: run functional tests
+    steps:
+      - run:
+          name: Install pitrery
+          command: make install
+      - run:
+          name: name install bats
+          command: ${PACKAGE_INSTALL} install bats
+      - run:
+          name: Change ownership
+          command: chown -R postgres:postgres ./tests/
+      - run:
+          name: Execute tests func
+          command: sudo -su postgres bats -t tests/func.bats
+
 
 jobs:
-  shellcheck:
-    docker: [{image: "koalaman/shellcheck-alpine:stable"}]
+  buster_12:
+    executor: buster
     steps:
-    - run: apk add git
-    - checkout
-    - run:
-        name: Shellcheck code analysis
-        command: shellcheck -f gcc pitrery archive_wal restore_wal
-  centos7:
-    <<: *tests-centos-job
+      - update-packages
+      - init-cluster-job
+      - checkout
+      - tests-func-job
+      - shellcheck-job
 
+  stretch_96:
+    executor: stretch
+    environment:
+      PG_VERSION: "9.6"
+    steps:
+      - update-packages
+      - init-cluster-job
+      - checkout
+      - tests-func-job
+
+  centos7_12:
+    executor: centos7
+    steps:
+      - init-cluster-job
+      - checkout
+      - tests-func-job
+
+  centos7_10:
+    executor: centos7
+    environment:
+      PG_VERSION: "10"
+    steps:
+      - init-cluster-job
+      - checkout
+      - tests-func-job
+
+  centos6_96:
+    executor: centos6
+    environment:
+      PG_VERSION: "9.6"
+    steps:
+      - init-cluster-job
+      - checkout
+      - tests-func-job
 
 workflows:
   version: 2
-  shellcheck:
+  spellcheck-and-functional:
     jobs:
-      - shellcheck
-  func:
-    jobs:
-      - centos7:
-          pg_version: '10'
-      - centos7
+      - buster_12
+      - stretch_96
+      - centos7_10
+      - centos7_12
+      - centos6_96

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 centos_env: &centos_env
   environment:
-    PACKAGE_INSTALL: "yum -y "
     PG_BINDIR: "/usr/pgsql-"
     PG_VERSION: 12
   shell: /bin/bash
@@ -10,7 +9,6 @@ centos_env: &centos_env
 
 debian_env: &debian_env
   environment:
-    PACKAGE_INSTALL: "apt -y "
     PG_BINDIR: "/usr/lib/postgresql/"
     PG_VERSION: 12
   shell: /bin/bash
@@ -34,19 +32,9 @@ executors:
     <<: *debian_env
 
 commands:
-  update-packages:
-    description: update packages
-    steps:
-      - run:
-          command: |
-            ${PACKAGE_INSTALL} update
-
   shellcheck-job:
     description: run shellcheck on scripts
     steps:
-      - run:
-          name: name install shellcheck
-          command: ${PACKAGE_INSTALL} install shellcheck
       - run:
           name: Shellcheck code analysis
           command: shellcheck -f gcc pitrery archive_wal restore_wal
@@ -76,9 +64,6 @@ commands:
           name: Install pitrery
           command: make install
       - run:
-          name: name install bats
-          command: ${PACKAGE_INSTALL} install bats
-      - run:
           name: Change ownership
           command: chown -R postgres:postgres ./tests/
       - run:
@@ -90,7 +75,6 @@ jobs:
   buster_12:
     executor: buster
     steps:
-      - update-packages
       - init-cluster-job
       - checkout
       - tests-func-job
@@ -101,7 +85,6 @@ jobs:
     environment:
       PG_VERSION: "9.6"
     steps:
-      - update-packages
       - init-cluster-job
       - checkout
       - tests-func-job

--- a/pitrery
+++ b/pitrery
@@ -1532,7 +1532,8 @@ case $action in
 				fi
 			}
 
-			# Check if the connection works by getting the pid of the backend
+			# Check if t
+			he connection works by getting the pid of the backend
 			echo 'select pg_backend_pid();' >&${COPROC[1]} # 2>/dev/null
 			if [ $? != 0 ]; then
 				check_psql_stderr || cat $psql_stderr
@@ -4107,7 +4108,7 @@ case $action in
 		# target directory for backups must be provided
 		if [ -z "${@:$OPTIND:1}" ]; then
 			error "missing target backup directory"
-			usage "configure"
+			usage "configure" 1
 		fi
 
 		# Only tar and rsync are allowed as storage method
@@ -4125,7 +4126,7 @@ case $action in
 			die "list of recipients for GPG encryption missing"
 		fi
 
-		parse_target_uri "${@:$OPTIND:1}" "$archive_path" || usage "configure"
+		parse_target_uri "${@:$OPTIND:1}" "$archive_path" || usage "configure" 1
 
 		# the configuration for archive_wal must be an absolute path or
 		# relative to PGDATA. Just convert it to a absolute path if needed,

--- a/tests/func.bats
+++ b/tests/func.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+setup()
+{
+	export PATH=/usr/local/bin/:$PATH
+	export PITRERY_BACKUP_DIR=/tmp/backup
+	export PITRERY_LOCAL_CONF=/tmp/pitrery_local.conf
+	export PITRERY_REMOTE_CONF=/tmp/pitrery_remote.conf
+	mkdir -p $PITRERY_BACKUP_DIR
+}
+
+#teardown()
+#{
+#	# teardown function
+#}
+
+@test "First dummy check - trying to run help action" {
+    run pitrery help
+	[ "${lines[0]}" == 'pitrery 3.1 - PostgreSQL Point In Time Recovery made easy' ]
+    echo "output = ${output}"
+}
+
+@test "Testing configure action without parameter" {
+  run pitrery configure
+  [ "$status" -eq 1 ]
+}
+
+@test "Testing backup action without config" {
+  run pitrery backup
+  [ "$status" -eq 1 ]
+}
+@test "Testing configure action with local parameters" {
+  run pitrery configure -f -o $PITRERY_LOCAL_CONF $PITRERY_BACKUP_DIR
+  [ "$status" -eq 0 ]
+}
+
+@test "Testing list action with local config and no backups" {
+  run pitrery -f $PITRERY_LOCAL_CONF list
+  [ "$status" -eq 1 ]
+}
+
+@test "Testing backup action with local config" {
+  run pitrery -f $PITRERY_LOCAL_CONF backup
+  [ "$status" -eq 0 ]
+  echo "output = ${output}"
+  [[ "$output" == *"INFO: preparing directories"* ]]
+  [[ "$output" == *"INFO: backing up PGDATA"* ]]
+  [[ "$output" == *"INFO: done"* ]]
+  # TODO get backup path name to verify next list test
+}
+
+@test "Testing list action with local config" {
+  run pitrery -f $PITRERY_LOCAL_CONF list
+  [ "$status" -eq 0 ]
+  IFS=$'\n'
+  output=(${output})
+  unset IFS
+  [ "${#output[@]}" -eq 2 ]
+  [[ "${output[1]}" == "$PITRERY_BACKUP_DIR"* ]]
+}


### PR DESCRIPTION
* [CI] Add conf for CentOS7 - PG9.6, 10, 11 & 12
  Co-authored-by: l00ptr <julian.vandenbroeck@dalibo.com>
   - Reuse temboard-agent-sdk docker image
     Simply re-use the centos temboard-agent-sdk image. So we don't have to define job just to install postgres through our circleci config file
   - Add shellcheck tests
     Run shellcheck checks for pitrery, archive_wal and restore_wal scripts.
   - Add first bunch of tests
     Test basic pitrery functions: direct call, configure, backup, list.

* [CI] refactorate cirecleci test file for centos and debian

   - Run shellcheck + functional tests debian buster - PG 12
   - Run functional tests debian stretch - PG 9.6
   - Run functional tests on CentOS 7 - PG 10 + 12
   - Run functional tests on CentOS 6 - PG 9.6