### PR TITLE
Issue 130: abort check if backup_timestamp is not available

### DIFF
--- a/pitrery
+++ b/pitrery
@@ -3623,6 +3623,9 @@ case $action in
 				else
 					ts=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
 				fi
+				if [ "$?" -ne "0" ]; then
+					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
+				fi
 
 				# The timestamp must be a string of (only) digits, we do arithmetic with it
 				if [[ $ts =~ ^[[:digit:]]+$ ]]; then
@@ -3721,6 +3724,9 @@ case $action in
 					ts=$(< "$dir/backup_timestamp")
 				else
 					ts=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
+				fi
+				if [ "$?" -ne "0" ]; then
+					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
 				fi
 
 				# The timestamp must be a string of (only) digits, we do arithmetic with it

--- a/pitrery
+++ b/pitrery
@@ -987,7 +987,7 @@ get_backup_timestamp() {
 		RC="$?"
 	fi
 
-	if [ $RC -eq 0 ]; then
+	if [ $RC = 0 ]; then
 		echo "$backup_timestamp"
 	else
 		echo ""
@@ -2288,7 +2288,7 @@ case $action in
 				# get the timestamp of the end of the backup
 				backup_timestamp=$(get_backup_timestamp $t)
 
-				if [[ $backup_timestamp =~ ^[[:digit:]]+$ ]]; then
+				if [[ $backup_timestamp =~ ^[[:digit:]]+$ ]] && [[ $? = 0 ]]; then
 					(( $backup_timestamp < $target_timestamp )) || break;
 					backup_dir=$(dirname -- "$t")
 				else
@@ -3125,7 +3125,7 @@ case $action in
 			ts=$(get_backup_timestamp "$dir")
 
 			# The timestamp must be a string of (only) digits, we do arithmetic with it
-			if [[ $ts =~ ^[[:digit:]]+$ ]]; then
+			if [[ $ts =~ ^[[:digit:]]+$ ]] && [[ $? = 0 ]]; then
 				candidates[$ts]=$dir
 			else
 				# We shouldn't normally ever be here, but if we are it's probably one

--- a/pitrery
+++ b/pitrery
@@ -3623,7 +3623,7 @@ case $action in
 				else
 					ts=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
 				fi
-				if [ "$?" -ne "0" ]; then
+				if [ $? != 0 ]; then
 					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
 				fi
 
@@ -3725,7 +3725,7 @@ case $action in
 				else
 					ts=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
 				fi
-				if [ "$?" -ne "0" ]; then
+				if [ $? != 0 ]; then
 					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
 				fi
 

--- a/pitrery
+++ b/pitrery
@@ -974,6 +974,17 @@ init_rsync_opts() {
 	fi
 }
 
+get_backup_timestamp() {
+	# $1 is a backup directory
+	local dir="$1"
+
+	if [ "$backup_local" = "yes" ]; then
+		ret_backup_timestamp=$(< "$dir/backup_timestamp")
+	else
+		ret_backup_timestamp=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
+	fi
+}
+
 while getopts "c:f:lV?" opt; do
 	case $opt in
 		c|f)
@@ -2265,11 +2276,8 @@ case $action in
 			# find the latest backup
 			for t in "${list[@]}"; do
 				# get the timestamp of the end of the backup
-				if [ "$backup_local" = "yes" ]; then
-					backup_timestamp=$(< "$t")
-				else
-					backup_timestamp=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$t")")
-				fi
+				get_backup_timestamp $t
+				backup_timestamp="$ret_backup_timestamp"
 
 				if [[ $backup_timestamp =~ ^[[:digit:]]+$ ]]; then
 					(( $backup_timestamp < $target_timestamp )) || break;
@@ -3105,11 +3113,8 @@ case $action in
 		# the reverse order.
 		candidates=()
 		for dir in "${list[@]%/}"; do
-			if [ "$backup_local" = "yes" ]; then
-				ts=$(< "$dir/backup_timestamp")
-			else
-				ts=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
-			fi
+			get_backup_timestamp "$dir"
+			ts="$ret_backup_timestamp"
 
 			# The timestamp must be a string of (only) digits, we do arithmetic with it
 			if [[ $ts =~ ^[[:digit:]]+$ ]]; then
@@ -3618,13 +3623,11 @@ case $action in
 			newest_ts=0
 			too_old="yes"
 			for dir in "${list[@]%/}"; do
-				if [ "$backup_local" = "yes" ]; then
-					ts=$(< "$dir/backup_timestamp")
-				else
-					ts=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
-				fi
+				get_backup_timestamp "$dir"
 				if [ $? != 0 ]; then
 					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
+				else
+					ts="$ret_backup_timestamp"
 				fi
 
 				# The timestamp must be a string of (only) digits, we do arithmetic with it
@@ -3720,13 +3723,11 @@ case $action in
 			oldest_ts=
 			oldest_dir=
 			for dir in "${list[@]%/}"; do
-				if [ "$backup_local" = "yes" ]; then
-					ts=$(< "$dir/backup_timestamp")
-				else
-					ts=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
-				fi
+				get_backup_timestamp "$dir"
 				if [ $? != 0 ]; then
 					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
+				else
+					ts="$ret_backup_timestamp"
 				fi
 
 				# The timestamp must be a string of (only) digits, we do arithmetic with it

--- a/pitrery
+++ b/pitrery
@@ -977,12 +977,22 @@ init_rsync_opts() {
 get_backup_timestamp() {
 	# $1 is a backup directory
 	local dir="$1"
+	local backup_timestamp
 
 	if [ "$backup_local" = "yes" ]; then
-		ret_backup_timestamp=$(< "$dir/backup_timestamp")
+		backup_timestamp=$(< "$dir/backup_timestamp")
+		RC="$?"
 	else
-		ret_backup_timestamp=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
+		backup_timestamp=$(ssh -n -- "$backup_ssh_target" "cat -- $(qw "$dir/backup_timestamp")")
+		RC="$?"
 	fi
+
+	if [ $RC -eq 0 ]; then
+		echo "$backup_timestamp"
+	else
+		echo ""
+	fi
+	return "$RC"
 }
 
 while getopts "c:f:lV?" opt; do
@@ -2276,8 +2286,7 @@ case $action in
 			# find the latest backup
 			for t in "${list[@]}"; do
 				# get the timestamp of the end of the backup
-				get_backup_timestamp $t
-				backup_timestamp="$ret_backup_timestamp"
+				backup_timestamp=$(get_backup_timestamp $t)
 
 				if [[ $backup_timestamp =~ ^[[:digit:]]+$ ]]; then
 					(( $backup_timestamp < $target_timestamp )) || break;
@@ -3113,8 +3122,7 @@ case $action in
 		# the reverse order.
 		candidates=()
 		for dir in "${list[@]%/}"; do
-			get_backup_timestamp "$dir"
-			ts="$ret_backup_timestamp"
+			ts=$(get_backup_timestamp "$dir")
 
 			# The timestamp must be a string of (only) digits, we do arithmetic with it
 			if [[ $ts =~ ^[[:digit:]]+$ ]]; then
@@ -3623,11 +3631,9 @@ case $action in
 			newest_ts=0
 			too_old="yes"
 			for dir in "${list[@]%/}"; do
-				get_backup_timestamp "$dir"
+				ts=$(get_backup_timestamp "$dir")
 				if [ $? != 0 ]; then
 					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
-				else
-					ts="$ret_backup_timestamp"
 				fi
 
 				# The timestamp must be a string of (only) digits, we do arithmetic with it
@@ -3723,11 +3729,9 @@ case $action in
 			oldest_ts=
 			oldest_dir=
 			for dir in "${list[@]%/}"; do
-				get_backup_timestamp "$dir"
+				ts=$(get_backup_timestamp "$dir")
 				if [ $? != 0 ]; then
 					die "The backup_timestamp file is missing from all/some directories in the backup directory. Please Fix it."
-				else
-					ts="$ret_backup_timestamp"
 				fi
 
 				# The timestamp must be a string of (only) digits, we do arithmetic with it


### PR DESCRIPTION
When the backup_timestamp is absent we should abort the check because something is wrong with the backup repository. (#130 )