### PR TITLE
CI: Move to dalibo/buildpack for shellcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: "sudo -su postgres PGVERSION=<< parameters.pgversion >> ./script/funcenv"
 
   shellcheck:
-    docker: [image: "dalibo/labs-sdk:buster"]
+    docker: [image: "dalibo/buildpack:alpine"]
     working_directory: /tmp/project/
     steps:
       - checkout

--- a/pitrery
+++ b/pitrery
@@ -644,14 +644,14 @@ check_remote_directory() {
 
 	dest_exists=$(ssh -n -- "$ssh_target" "[ -e $(qw "$dest_dir") ] || echo 'ko'")
 	if [ $? = 0 ]; then
-		if [ ! -n "$dest_exists" ]; then
+		if [ -n "$dest_exists" ]; then
 			dest_isdir=$(ssh -n -- "$ssh_target" "[ -d $(qw "$dest_dir") ] || echo 'ko'")
 			if [ $? = 0 ]; then
-				if [ ! -n "$dest_isdir" ]; then
+				if [ -z "$dest_isdir" ]; then
 					info "target directory '$dest_dir' exists"
 					dest_writable=$(ssh -n -- "$ssh_target" "[ -w $(qw "$dest_dir") ] || echo 'ko'")
 					if [ $? = 0 ]; then
-						if [ ! -n "$dest_writable" ]; then
+						if [ -z "$dest_writable" ]; then
 							info "target directory '$dest_dir' is writable"
 						else
 							error "target directory '$dest_dir' is NOT writable"


### PR DESCRIPTION
No need to pull all postgres binaries for shellcheck.