### PR TITLE
Fix #161 : check fails on a correct remote directory

### DIFF
--- a/pitrery
+++ b/pitrery
@@ -644,7 +644,7 @@ check_remote_directory() {
 
 	dest_exists=$(ssh -n -- "$ssh_target" "[ -e $(qw "$dest_dir") ] || echo 'ko'")
 	if [ $? = 0 ]; then
-		if [ -n "$dest_exists" ]; then
+		if [ -z "$dest_exists" ]; then
 			dest_isdir=$(ssh -n -- "$ssh_target" "[ -d $(qw "$dest_dir") ] || echo 'ko'")
 			if [ $? = 0 ]; then
 				if [ -z "$dest_isdir" ]; then


### PR DESCRIPTION
Issue #161 
Fix of a typo in commit 59078c1ceb1750a120a43080a92dc3f192369d57
(this commit seems to aim to replace `! -n` by `-z` and the 1st occurence was replaced by `-n`)
The check on a remote directory wrongly failed (or wrongly succeeded and failed with a false message later)